### PR TITLE
Fix monitor constructor call when no monitor is defined in settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ def main():
             for index, monitor in enumerate(monitors):
                 monitor.run(index)
         else:
-            Monitor(check_interval, config["artist_ids"], config, api, seen, token_switcher, hooks, output, config.get("num_threads", 3), 0).run()
+            Monitor(check_interval, config["artist_ids"], config, api, seen, token_switcher, hooks, output, config.get("num_threads", 3)).run(0)
 
         output.run_loop()
         


### PR DESCRIPTION
Previously, when no monitor was defined in `settings.json`, `main.py` would attempt to call the constructor of `Monitor` with 11 arguments instead of 10 and the run method without an index, causing an exception.
This behavior was introduced with commit afa1f8d due to a misplaced `0`.

This commit fixes this by moving the superfluous `0` argument from the constructor call to the index parameter of the run method call.